### PR TITLE
Exclude uri?

### DIFF
--- a/src/cognitect/transit.cljs
+++ b/src/cognitect/transit.cljs
@@ -13,7 +13,7 @@
 ;; limitations under the License.
 
 (ns cognitect.transit
-  (:refer-clojure :exclude [integer? uuid uuid?])
+  (:refer-clojure :exclude [integer? uuid uuid? uri?])
   (:require [com.cognitect.transit :as t]
             [com.cognitect.transit.types :as ty]
             [com.cognitect.transit.eq :as eq])


### PR DESCRIPTION
Resolves warning with recent clojurescript builds

WARNING: uri? already refers to: cljs.core/uri? being replaced by: cognitect.transit/uri? at line 332 resources\public\js\dev\cognitect\transit.cljs

Ref Issue #39 