### PR TITLE
TCLJS-58: write-handler config differs from transit-clj

### DIFF
--- a/src/cognitect/transit.cljs
+++ b/src/cognitect/transit.cljs
@@ -300,6 +300,10 @@
   [from-rep]
   from-rep)
 
+(defn- fn-or-val
+  [f]
+  (if (fn? f) f (constantly f)))
+
 (defn write-handler
   "Creates a transit write handler whose tag, rep,
    stringRep, and verboseWriteHandler methods
@@ -309,12 +313,16 @@
   ([tag-fn rep-fn str-rep-fn]
      (write-handler tag-fn rep-fn str-rep-fn nil))
   ([tag-fn rep-fn str-rep-fn verbose-handler-fn]
+   (let [tag-fn (fn-or-val tag-fn)
+         rep-fn (fn-or-val rep-fn)
+         str-rep-fn (fn-or-val str-rep-fn)
+         verbose-handler-fn (fn-or-val verbose-handler-fn)]
      (reify
        Object
        (tag [_ o] (tag-fn o))
        (rep [_ o] (rep-fn o))
        (stringRep [_ o] (when str-rep-fn (str-rep-fn o)))
-       (getVerboseHandler [_] (when verbose-handler-fn (verbose-handler-fn))))))
+       (getVerboseHandler [_] (when verbose-handler-fn (verbose-handler-fn)))))))
 
 ;; =============================================================================
 ;; Constructors & Predicates

--- a/test/transit/test/core.cljs
+++ b/test/transit/test/core.cljs
@@ -222,6 +222,14 @@
              {:default (fn [tag value] (t/tagged-value tag value))}})]
     (is (t/tagged-value? (first (t/read r "[\"~q1\"]"))))))
 
+(deftest test-tcljs-58
+  (testing "write handlers can take values for config"
+    (let [sorted-set-write-handler (t/write-handler "sorted-set" (fn [o] (vec o)))
+          w (t/writer :json-verbose
+              {:handlers {cljs.core/PersistentTreeSet sorted-set-write-handler}})]
+      (is (= "{\"~#sorted-set\":[1,2,3,4]}"
+             (t/write w (sorted-set 3 4 1 2)))))))
+
 (defn -main [& args]
   (run-tests))
 


### PR DESCRIPTION
write-handler should be able to take non-fn values and these will get wrapped in constantly.